### PR TITLE
add --always to describe

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export default class ServerlessGitVariables {
     let value = null
     switch (variable) {
       case 'describe':
-        value = await _exec('git describe')
+        value = await _exec('git describe --always')
         break
       case 'sha1':
         value = await _exec('git rev-parse --short HEAD')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -42,12 +42,10 @@ test('Rejects on bad key', async t => {
 })
 
 test.serial('Rejects on bad git command', async t => {
-  fs.copySync('test/resources/simple_repo/git', `${t.context.tmpDir}/.git`)
   process.chdir(t.context.tmpDir)
-
   const sls = buildSls()
-  sls.service.custom.describe = '${git:describe}' // eslint-disable-line
-  await t.throws(sls.variables.populateService(), /Error: Command failed: git describe/)
+  sls.service.custom.describe = '${git:message}' // eslint-disable-line
+  await t.throws(sls.variables.populateService(), /Not a git repository/)
 })
 
 test.serial('Inserts variables', async t => {


### PR DESCRIPTION
At the moment git:describe fails with `fatal: No names found, cannot describe anything.` if the git repository does not contain any names. 

I added `--always` to the git describe command so that it will not fail in these cases and will instead revert to short hash.