### PR TITLE
Add environment variables and tags with GIT values, before deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 [![Build Status](https://travis-ci.org/jacob-meacham/serverless-plugin-git-variables.svg?branch=develop)](https://travis-ci.org/jacob-meacham/serverless-plugin-git-variables)
 
 Expose git variables (HEAD description, branch name, short commit hash, message, and if the local repo has changed files) to your serverless services.
-Moreover, it adds GIT related environment variables and tags (GIT_COMMIT_SHORT, GIT_COMMIT_LONG, GIT_BRANCH, GIT_IS_DIRTY) for each defined function in the serverless file.
+Moreover, it adds GIT related environment variables and tags (GIT_COMMIT_SHORT, GIT_COMMIT_LONG, GIT_BRANCH, GIT_IS_DIRTY) for each defined function in the serverless file. You can disable this adding the following custom variable in your serverless.yml file:
+
+```
+custom:
+  exportGitVariables: false
+```
 
 # Usage
 ```yaml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![Coverage Status](https://coveralls.io/repos/github/jacob-meacham/serverless-plugin-git-variables/badge.svg?branch=develop)](https://coveralls.io/github/jacob-meacham/serverless-plugin-git-variables?branch=develop)
 [![Build Status](https://travis-ci.org/jacob-meacham/serverless-plugin-git-variables.svg?branch=develop)](https://travis-ci.org/jacob-meacham/serverless-plugin-git-variables)
 
-Expose git variables (HEAD description, branch name, short commit hash, and message) to your serverless services.
+Expose git variables (HEAD description, branch name, short commit hash, message, and if the local repo has changed files) to your serverless services.
+Moreover, it adds GIT related environment variables and tags (GIT_COMMIT_SHORT, GIT_COMMIT_LONG, GIT_BRANCH, GIT_IS_DIRTY) for each defined function in the serverless file.
 
 # Usage
 ```yaml

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,11 +92,9 @@ class ServerlessGitVariables {
           value = yield _exec('git log -1 --pretty=%B');
           break;
         case 'isDirty':
-          value = yield _exec('git write-tree').then(function (writeTree) {
-            return _exec(`git diff-index ${writeTree} --`);
-          }).then(function (changes) {
-            return `${changes.length > 0}`;
-          });
+          const writeTree = yield _exec('git write-tree');
+          const changes = yield _exec(`git diff-index ${writeTree} --`);
+          value = `${changes.length > 0}`;
           break;
         default:
           throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'sha1', 'commit', 'branch', 'message'`);
@@ -114,6 +112,11 @@ class ServerlessGitVariables {
   }
 
   exportGitVariables() {
+    const exportGitVariables = this.serverless.service.custom && this.serverless.service.custom.exportGitVariables;
+    if (exportGitVariables === false) {
+      return _promise2.default.resolve();
+    }
+
     const promises = this.serverless.service.getAllFunctions().map(functionName => {
       return _promise2.default.all([this._getValue('sha1'), this._getValue('commit'), this._getValue('branch'), this._getValue('isDirty')]).then(([sha1, commit, branch, isDirty]) => {
         const func = this.serverless.service.getFunction(functionName);

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const GIT_PREFIX = 'git'; // TODO: Consider using nodegit instead
 class ServerlessGitVariables {
   constructor(serverless, options) {
+    this.serverless = serverless;
     this.resolvedValues = {};
     const delegate = serverless.variables.getValueFromSource.bind(serverless.variables);
 
@@ -49,6 +50,11 @@ class ServerlessGitVariables {
       }
 
       return delegate(variableString);
+    };
+    this.hooks = {
+      'after:package:initialize': this.exportGitVariables.bind(this),
+      'before:offline:start': this.exportGitVariables.bind(this),
+      'before:offline:start:init': this.exportGitVariables.bind(this)
     };
   }
 
@@ -85,6 +91,13 @@ class ServerlessGitVariables {
         case 'message':
           value = yield _exec('git log -1 --pretty=%B');
           break;
+        case 'isDirty':
+          value = yield _exec('git write-tree').then(function (writeTree) {
+            return _exec(`git diff-index ${writeTree} --`);
+          }).then(function (changes) {
+            return `${changes.length > 0}`;
+          });
+          break;
         default:
           throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'sha1', 'commit', 'branch', 'message'`);
       }
@@ -98,6 +111,33 @@ class ServerlessGitVariables {
       _this2.resolvedValues[variable] = value;
       return value;
     })();
+  }
+
+  exportGitVariables() {
+    const promises = this.serverless.service.getAllFunctions().map(functionName => {
+      return _promise2.default.all([this._getValue('sha1'), this._getValue('commit'), this._getValue('branch'), this._getValue('isDirty')]).then(([sha1, commit, branch, isDirty]) => {
+        const func = this.serverless.service.getFunction(functionName);
+        this.exportGitVariable(func, 'GIT_COMMIT_SHORT', sha1);
+        this.exportGitVariable(func, 'GIT_COMMIT_LONG', commit);
+        this.exportGitVariable(func, 'GIT_BRANCH', branch);
+        this.exportGitVariable(func, 'GIT_IS_DIRTY', isDirty);
+      });
+    });
+    return _promise2.default.all(promises);
+  }
+
+  exportGitVariable(func, variableName, gitValue) {
+    if (!func.environment[variableName]) {
+      func.environment[variableName] = gitValue;
+    }
+
+    if (!func.tags) {
+      func.tags = {};
+    }
+
+    if (!func.tags[variableName]) {
+      func.tags[variableName] = gitValue;
+    }
   }
 }
 exports.default = ServerlessGitVariables;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-git-variables",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "engines": {
     "node": ">=7.0"
   },
@@ -23,7 +23,8 @@
     "aws lambda",
     "amazon",
     "amazon web services",
-    "serverless.com"
+    "serverless.com",
+    "git"
   ],
   "main": "lib/index.js",
   "files": [

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -78,3 +78,36 @@ test('Returns cached value as promise', async t => {
     t.is(value, fakeTag)
   })
 })
+
+test('Env variables defined', async t => {
+  fs.copySync('test/resources/full_repo/git', `${t.context.tmpDir}/.git`)
+  process.chdir(t.context.tmpDir)
+
+  const func = {
+    name: 'myFunction',
+    environment: {}
+  }
+
+  const fakeServerless = {
+    service: {
+      getAllFunctions: () => [func.name],
+      getFunction: name => func
+    },
+    variables: {
+      getValueFromSource: () => 'fake'
+    }
+  }
+
+  const plugin = new ServerlessGitVariables(fakeServerless, {})
+  await plugin.exportGitVariables()
+
+  t.is(func.environment.GIT_COMMIT_SHORT, '90440bd')
+  t.is(func.environment.GIT_COMMIT_LONG, '90440bdc8eb3b2fa20bc578f411cf4b725ae0a25')
+  t.is(func.environment.GIT_BRANCH, 'another_branch')
+  t.is(func.environment.GIT_IS_DIRTY, 'true')
+
+  t.is(func.tags.GIT_COMMIT_SHORT, '90440bd')
+  t.is(func.tags.GIT_COMMIT_LONG, '90440bdc8eb3b2fa20bc578f411cf4b725ae0a25')
+  t.is(func.tags.GIT_BRANCH, 'another_branch')
+  t.is(func.tags.GIT_IS_DIRTY, 'true')
+})

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -79,7 +79,7 @@ test('Returns cached value as promise', async t => {
   })
 })
 
-test('Env variables defined', async t => {
+test.serial('Env variables defined', async t => {
   fs.copySync('test/resources/full_repo/git', `${t.context.tmpDir}/.git`)
   process.chdir(t.context.tmpDir)
 
@@ -104,10 +104,40 @@ test('Env variables defined', async t => {
   t.is(func.environment.GIT_COMMIT_SHORT, '90440bd')
   t.is(func.environment.GIT_COMMIT_LONG, '90440bdc8eb3b2fa20bc578f411cf4b725ae0a25')
   t.is(func.environment.GIT_BRANCH, 'another_branch')
-  t.is(func.environment.GIT_IS_DIRTY, 'true')
+  t.is(func.environment.GIT_IS_DIRTY, 'false')
 
   t.is(func.tags.GIT_COMMIT_SHORT, '90440bd')
   t.is(func.tags.GIT_COMMIT_LONG, '90440bdc8eb3b2fa20bc578f411cf4b725ae0a25')
   t.is(func.tags.GIT_BRANCH, 'another_branch')
-  t.is(func.tags.GIT_IS_DIRTY, 'true')
+  t.is(func.tags.GIT_IS_DIRTY, 'false')
+})
+
+test.serial('Disabling export of env variables', async t => {
+  fs.copySync('test/resources/full_repo/git', `${t.context.tmpDir}/.git`)
+  process.chdir(t.context.tmpDir)
+
+  const func = {
+    name: 'myFunction',
+    environment: {}
+  }
+
+  const fakeServerless = {
+    service: {
+      getAllFunctions: () => [func.name],
+      getFunction: name => func,
+      custom: { exportGitVariables: false }
+    },
+    variables: {
+      getValueFromSource: () => 'fake'
+    }
+  }
+  const plugin = new ServerlessGitVariables(fakeServerless, {})
+  await plugin.exportGitVariables()
+
+  t.is(func.environment.GIT_COMMIT_SHORT, undefined)
+  t.is(func.environment.GIT_COMMIT_LONG, undefined)
+  t.is(func.environment.GIT_BRANCH, undefined)
+  t.is(func.environment.GIT_IS_DIRTY, undefined)
+
+  t.is(func.tags, undefined)
 })


### PR DESCRIPTION
It includes as environment variables and tags the following items:
* GIT_COMMIT_SHORT
* GIT_COMMIT_LONG
* GIT_BRANCH
* GIT_IS_DIRTY

In the lambda code, you could access these variables as `process.env.GIT_COMMIT_SHORT`, for instance.

And I've added a new GIT variable (available in serverless.yml and as env/tag variable) called `isDirty`, that would be `true` is the local repository has some changed not commited and `false` otherwise.

Moreover, I've added tests.