### PR TITLE
Initialize `func.environment` if unset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,10 @@ export default class ServerlessGitVariables {
   }
 
   exportGitVariable(func, variableName, gitValue) {
+    if (!func.environment) {
+      func.environment = {}
+    }
+
     if (!func.environment[variableName]) {
       func.environment[variableName] = gitValue
     }


### PR DESCRIPTION
This fixed the error I was having: `Cannot read property 'GIT_COMMIT_SHORT' of undefined`

Note that I have little knowledge of Serverless and its plugins - hope this change makes sense!