### PR TITLE
Add lightweight tags variable funcionality, resolves #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ functions:
 
   processEventBatch2:
     name: ${self:provider.stage}-${self:service}-process-event-batch-2
-    description: ${git:describeLight} - Dirty: ${git:isDirty}
+    description: ${git:describeLight} - ${git:branch}
 
 plugins:
   - serverless-plugin-git-variables

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ plugins:
   - serverless-plugin-git-variables
 ```
 
+## describe and describeLight
+The describe (`${git:describe}`) and the describeLight (`${git:describeLight}`) variables are both used to return the most recent tag of the repo. However the difference is that whilst `describe` evaluates to `git describe --always`, the `describeLight` variable evaluates to `git describe --always --tags`.  
+`--always` will ensure that if no tags are present, the commit hash is shown as a fallback option. (See [git describe documentation](https://git-scm.com/docs/git-describe) for more information).
+
+Annotated tags are shown by both `describe` and `describeLight`, only `describeLight` will show lightweight tags (such as those generated when using GitHub's releases feature).
+
+For more information on annotated and lightweight tags go to the [git documentation on tagging](https://git-scm.com/book/en/v2/Git-Basics-Tagging).
+
 # Serverless Version Support
 * If you're using serverless 1.12.x or below, use the 1.x.x version of this plugin.
 * This plugin is currently broken for serverless versions between 1.13 and 1.15 (inclusive).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ functions:
     name: ${self:provider.stage}-${self:service}-process-event-batch
     description: ${git:branch} - ${git:describe} - ${git:sha1}
 
+  processEventBatch2:
+    name: ${self:provider.stage}-${self:service}-process-event-batch-2
+    description: ${git:describeLight} - Dirty: ${git:isDirty}
+
 plugins:
   - serverless-plugin-git-variables
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ export default class ServerlessGitVariables {
         value = `${changes.length > 0}`
         break
       default:
-        throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'sha1', 'commit', 'branch', 'message'`)
+        throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'describeLight', 'sha1', 'commit', 'branch', 'message'`)
     }
 
     // TODO: Figure out why if I don't log, the deasync promise

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,9 @@ export default class ServerlessGitVariables {
       case 'describe':
         value = await _exec('git describe --always')
         break
+      case 'describeLight':
+        value = await _exec('git describe --always --tags')
+        break
       case 'sha1':
         value = await _exec('git rev-parse --short HEAD')
         break

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -59,6 +59,7 @@ test.serial('Inserts variables', async t => {
   sls.service.custom.branch = '${git:branch}' // eslint-disable-line
   sls.service.custom.describe2 = '${git:describe}' // eslint-disable-line
   sls.service.custom.message = '${git:message}' // eslint-disable-line
+  sls.service.custom.describeLight = '${git:describeLight}' // eslint-disable-line
   await sls.variables.populateService()
 
   t.is(sls.service.custom.sha1, '90440bd')
@@ -67,6 +68,7 @@ test.serial('Inserts variables', async t => {
   t.is(sls.service.custom.describe, 'my_tag-1-g90440bd')
   t.is(sls.service.custom.describe2, 'my_tag-1-g90440bd')
   t.is(sls.service.custom.message, 'Another commit')
+  t.is(sls.service.custom.describeLight, 'my_tag-1-g90440bd')
 })
 
 test('Returns cached value as promise', async t => {


### PR DESCRIPTION
This Pull Request adds the ability for users to use a variable in serverless `${git:describeLight}`
 that will resolve to `git describe --always --tags`. This is desirable because it will allow the display of lightweight tags (such as those generated when using GitHub releases). resolves #14 

## Checklist

- [x] Functionality added
- [x] Example in README added
- [x] Test added
- [x] Tests passed
- [x] Linting passed