### PR TITLE
Enabled version to be retrieved from package.json 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ plugins:
 
 resources:
   Description: >
-    ${self:service} ${git:branch}:${git:sha1}
+    ${self:service} ${git:npmVersion} ${git:branch}:${git:sha1}
     https://github.com/jacob-meacham/serverless-plugin-git-variables
     ${git:message}
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -65,13 +65,16 @@ export default class ServerlessGitVariables {
       case 'message':
         value = await _exec('git log -1 --pretty=%B')
         break
+      case 'npmVersion':
+        value = require('../../../package.json').version;
+        break;
       case 'isDirty':
         const writeTree = await _exec('git write-tree')
         const changes = await _exec(`git diff-index ${writeTree} --`)
         value = `${changes.length > 0}`
         break
       default:
-        throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'describeLight', 'sha1', 'commit', 'branch', 'message'`)
+        throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'describeLight', 'npmVersion', 'sha1', 'commit', 'branch', 'message'`)
     }
 
     // TODO: Figure out why if I don't log, the deasync promise


### PR DESCRIPTION
When using this plug-in I ran into the issue that the adding of git tag only happens _after_ a release has been deployed to production (when using standard git workflow in most projects), but package.json version is usually incremented _before_ releasing to production.

Therefore added possibility to retrieve version number from package.json as it is more accurate in what is current version number in most projects using git flow.