### PR TITLE
Fixes #25

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,8 +109,7 @@ class ServerlessGitVariables {
           value = yield _exec('git config user.email');
           break;
         case 'isDirty':
-          const writeTree = yield _exec('git write-tree');
-          const changes = yield _exec(`git diff-index ${writeTree} --`);
+          const changes = yield _exec(`git diff --stat`);
           value = `${changes.length > 0}`;
           break;
         case 'repository':

--- a/src/index.js
+++ b/src/index.js
@@ -74,8 +74,7 @@ export default class ServerlessGitVariables {
         value = await _exec('git config user.email')
         break
       case 'isDirty':
-        const writeTree = await _exec('git write-tree')
-        const changes = await _exec(`git diff-index ${writeTree} --`)
+        const changes = await _exec(`git diff --stat`)
         value = `${changes.length > 0}`
         break
       case 'repository':


### PR DESCRIPTION
The command git write-tree fails when multiple git processes are trying to do the write operation in the same repo. This typically happen when you are deploying multiple stacks in same repository in parallel using e.g. Jenkins.