### PR TITLE
Fix module default export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -207,3 +207,4 @@ class ServerlessGitVariables {
 }
 
 exports.default = ServerlessGitVariables;
+module.exports = exports.default;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-git-variables",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2303,6 +2303,12 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
+    },
+    "babel-plugin-add-module-exports": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz",
+      "integrity": "sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==",
       "dev": true
     },
     "babel-plugin-dynamic-import-node": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/preset-env": "7.12.1",
     "@babel/register": "7.12.1",
     "ava": "3.13.0",
+    "babel-plugin-add-module-exports": "1.0.4",
     "coveralls": "3.1.0",
     "cross-env": "7.0.2",
     "eslint": "7.12.1",
@@ -78,9 +79,13 @@
         {
           "targets": {
             "node": 12
-          }
+          },
+          "modules": "commonjs"
         }
       ]
+    ],
+    "plugins": [
+      "add-module-exports"
     ]
   }
 }


### PR DESCRIPTION
Upgrading to v5 has caused issues with serverless deployments for me.

Serverless's PluginManager calls [`loadAllPlugins`](https://github.com/serverless/serverless/blob/master/lib/classes/PluginManager.js#L124) > [`addPlugin`](https://github.com/serverless/serverless/blob/master/lib/classes/PluginManager.js#L94), which instantiates the plugin. It expects the plugin to be exported via `module.exports`:

In the current build:

```
> require('serverless-plugin-git-variables')
{ default: [class ServerlessGitVariables] }
```

In this branch:

```
> require('.')
[class ServerlessGitVariables]
```
