### PR TITLE
Use en_US locale for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "scripts": {
     "lint": "eslint .",
     "eslint": "eslint",
-    "test": "nyc ava",
-    "test:watch": "ava --watch",
+    "test": "LANG=en_US nyc ava",
+    "test:watch": "LANG=en_US ava --watch",
     "build:node": "cross-env BABEL_ENV=production babel src --out-dir lib",
     "build": "npm run lint && npm run test && npm run build:node",
     "ci:coverage": "nyc report --reporter=text-lcov | coveralls"


### PR DESCRIPTION
Some tests assert on the output from git commands, which depends on system locale.
On my system, using `sv_SE` locale, one test would fail on asserted regex
`/N|not a git repository*/` not matching the output from my Swedish `git` installation.

Fixed simply by forcing `en_US` locale only for the tests, since the locale doesn't really
matter during normal use.