### PR TITLE
Extend timeouts to 10sec for git commands

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const GIT_PREFIX = 'git';
 
 async function _exec(cmd, options = {
-  timeout: 1000
+  timeout: 10000
 }) {
   return new Promise((resolve, reject) => {
     _child_process.default.exec(cmd, options, (err, stdout) => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import os from 'os'
 
 const GIT_PREFIX = 'git'
 
-async function _exec(cmd, options = { timeout: 1000 }) {
+async function _exec(cmd, options = { timeout: 10000 }) {
   return new Promise((resolve, reject) => {
     childProcess.exec(cmd, options, (err, stdout) => {
       if (err) {


### PR DESCRIPTION
### What?
This PR extends the timeout from 1sec to 10secs for all git commands. 

### Why?
This fixes a common issue where git command times out due to a 1sec limit:
https://github.com/jacob-meacham/serverless-plugin-git-variables/issues/28