### PR TITLE
Use a more generic way to pull repo name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,8 +85,8 @@ export default class ServerlessGitVariables {
         break
       }
       case 'repository': {
-        const pathName = await _exec('git rev-parse --show-toplevel')
-        value = path.basename(pathName)
+        const pathName = await _exec('git config --get remote.origin.url')
+        value = path.basename(pathName, ".git")
         break
       }
       case 'tags':


### PR DESCRIPTION
Extracting the repo name from the folder into which the git repo was cloned is dangerous. Mainly because the folder name can change. This is a more robust way of pooling it.

See https://stackoverflow.com/a/42543006